### PR TITLE
Unify time formats

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,7 +24,7 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="8dp"
         android:layout_above="@id/bottom_navigation"
-        android:format12Hour="hh:mm a"
+        android:format24Hour="H:mm"
         android:textColor="#ffffff"
         android:textSize="45dp"
         android:textStyle="bold"


### PR DESCRIPTION
The clock currently displays 12 hour time, while the event data displays ~glorious~ 24 hour time. This just deletes 12 hour formatting so that they're consistent.